### PR TITLE
Misc clumsy cosmetic tweaks

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -71,7 +71,7 @@ async function logout() {
 
 <template>
   <div class="container mx-auto p-10 min-h-screen flex flex-col">
-    <header class="py-10">
+    <header class="py-2">
       <div class="h-10 -mt-10">
         <a
           id="skip-link"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -49,7 +49,7 @@ const apps = computed(() => {
   <div>
     <PageTitle :text="$t('app_list')" />
 
-    <div id="apps" class="my-10">
+    <div id="apps">
       <div v-if="!apps.length" class="w-2/3">
         <em>{{ t('no_apps') }}</em>
       </div>
@@ -60,9 +60,8 @@ const apps = computed(() => {
           :key="app.id"
           class="leading-none card h-40 w-40 relative mr-7 mb-7"
         >
-          <div class="tile-layer" :class="[app.colors[0], 'brightness-75']" />
           <a :href="app.url" class="tile-layer p-5" :class="app.colors">
-            <div class="text-6xl font-extrabold mb-1" aria-hidden="true">
+            <div class="text-6xl font-extrabold mb-1 mt-2" aria-hidden="true">
               {{ app.label.substring(0, 2) }}
             </div>
             <span class="leading-tight mt-2">{{ app.label }}</span>
@@ -85,14 +84,14 @@ const apps = computed(() => {
   z-index: -1;
   position: absolute;
   @apply inset-0;
-  @apply rounded-2xl;
+  @apply text-center;
   transform: translate(0rem, 0rem);
 }
-#apps li.card:hover div.tile-layer {
-  transform: translate(0.75rem, 0.75rem);
-}
-
 #apps li.card:hover {
-  transform: translate(-0.75rem, -0.75rem);
+  height: 9.5em;
+  width: 9.5em;
+  margin-left: 0.25em;
+  margin-top: 0.25em;
+  transition: all 0.1s ease;
 }
 </style>


### PR DESCRIPTION
Soooo this is me trying to improve misc cosmetic stuff though I don't know how to do everything in the right way :sweat_smile: 

- Not a huge fan of the `rounded-2xl` + the offset transition on the app tile so I'm proposing to switch to a "squary-square" tile + centered text + have it shrink (or grow?) on hovering ?
- Proposing to drastically reduce the margins between header and app list

Stuff I didnt quite find how to do / or bugs ? : 
- Reduce the min-size for `.btn` from 3em to 2.5em ... because right now it feels like buttons are too "bulky" ? (especially compared to the webadmin, though the point ain't really to exactly match the webadmin I guess)
- The "App list" title between the header and tile list seems unecessary ... though it's related to having a clear `h1` + main content flag for a11y as far as i understand ... but isnt there to have only like a label/descr for screen readers only ? Or is it a bad practice to hide such text ? 
- The "Skip to main content" at the top seems buggy, it's not displayed when I inially open the portal, then is shown on "Edit this profile" page, and then is still shown when going back to the app list page
- Let's re-add the "pencil" icon near the header (with the person's name etc) + support clicking on the header to go to "Edit the profile" ?
- Move the theme selector to the profile ?
- In the "Email addresses" thing, on top of the "Add an email alias", we should display somehow the main email address as a read-only info ... + possibly add a link to https://yunohost.org/email_configure_client