### PR TITLE
Fix: user profile link in header + i18n language load + change

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,5 +19,6 @@ module.exports = {
       },
     ],
     camelcase: 'warn',
+    'vue/no-v-html': 'off',
   },
 }

--- a/composables/states.ts
+++ b/composables/states.ts
@@ -25,7 +25,7 @@ const usePreferedLocaleState = () =>
 
 export const usePreferedLocale = () => {
   const preferedLocale = usePreferedLocaleState()
-  const { locale, getBrowserLocale, defaultLocale } = useNuxtApp().$i18n
+  const { getBrowserLocale, defaultLocale, setLocale } = useNuxtApp().$i18n
 
   return computed({
     get: () => preferedLocale.value,
@@ -37,8 +37,7 @@ export const usePreferedLocale = () => {
         const browserLocale = getBrowserLocale()
         value = browserLocale || defaultLocale
       }
-
-      locale.value = value
+      setLocale(value)
     },
   })
 }

--- a/composables/states.ts
+++ b/composables/states.ts
@@ -112,7 +112,7 @@ export const useSettings = async () => {
 
     const logo = data.value!.portal_logo as unknown as string | undefined
     if (logo) {
-      const src = `https://${data.value.domain}/yunohost/sso/customassets/${logo}`
+      const src = `https://${data.value!.domain}/yunohost/sso/customassets/${logo}`
       const is = logo.slice(-4) === '.svg' ? 'svg' : 'img'
       data.value!.portal_logo = { is, src: is === 'svg' ? '' : src }
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -72,24 +72,24 @@ async function logout() {
             class="flex flex-grow flex-wrap min-[500px]:w-full max-[500px]:flex-col max-[500px]:ms-auto"
           >
             <div v-if="user" class="flex-grow">
-              <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events vuejs-accessibility/no-static-element-interactions -->
-              <div
-                class="profile cursor-pointer flex flex-col"
-                @click="navigateTo('/edit')"
-              >
+              <div class="profile flex flex-col">
                 <span>
                   <span
-                    class="text-2xl font-extrabold tracking-tight leading-none"
+                    class="text-2xl font-extrabold tracking-tight leading-none me-2"
                   >
                     {{ user.username }}
                   </span>
-                  <YIcon name="pencil" size="1.25em" class="ms-2" />
+
+                  <NuxtLink to="/edit" class="link profile-link">
+                    <YIcon name="pencil" size="1.25em" />
+                    <span class="sr-only">{{ t('footerlink_edit') }}</span>
+                    <span class="text" aria-hidden="true">
+                      {{ t('footerlink_edit') }}
+                    </span>
+                  </NuxtLink>
                 </span>
                 <span class="leading-none">{{ user.fullname }}</span>
                 <span class="opacity-50">{{ user.mail }}</span>
-                <NuxtLink to="/edit" class="link sr-only focus:not-sr-only">
-                  {{ t('footerlink_edit') }}
-                </NuxtLink>
               </div>
             </div>
             <p
@@ -147,8 +147,12 @@ header .logo {
   width: 100px;
 }
 
-header .profile:not(:hover) .nuxt-icon {
+.profile-link .text {
   display: none;
+}
+.profile-link:hover .text,
+.profile-link:focus .text {
+  display: inline;
 }
 
 .focus-target:not(:focus-visible) {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -7,7 +7,7 @@ const queryMsg = useQueryMsg()
 const settings = await useSettings()
 const user = await useUser<User | null>()
 
-const footerLinks = [
+const footerLinks = computed(() => [
   { text: t('footerlink_edit'), to: '/edit' },
   {
     text: t('footerlink_documentation'),
@@ -20,7 +20,7 @@ const footerLinks = [
     to: `//${settings.value.domain}/yunohost/admin/`,
     newWindow: true,
   },
-]
+])
 
 async function logout() {
   const { error } = await useApi('/logout')

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -54,4 +54,5 @@ export default defineNuxtConfig({
     dataValue: 'theme',
     classSuffix: '',
   },
+  compatibilityDate: '2024-09-24',
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -45,9 +45,6 @@ export default defineNuxtConfig({
     lazy: true,
     langDir: 'locales',
     locales: locales as LocaleObject[],
-    detectBrowserLanguage: {
-      useCookie: false,
-    },
   },
   colorMode: {
     preference: 'system',

--- a/plugins/i18n.ts
+++ b/plugins/i18n.ts
@@ -1,5 +1,5 @@
 import { setLocale } from 'yup'
-import { usePreferedLocale, usePreferedTheme } from '@/composables/states'
+import { usePreferedTheme } from '@/composables/states'
 
 export default defineNuxtPlugin({
   async setup() {
@@ -21,14 +21,5 @@ export default defineNuxtPlugin({
     if (preferedTheme.value !== 'auto') {
       colorMode.preference = preferedTheme.value
     }
-  },
-  hooks: {
-    'app:created'() {
-      // Override browser locale if prefered language
-      const preferedLocale = usePreferedLocale()
-      if (preferedLocale.value !== 'auto') {
-        useNuxtApp().$i18n.locale.value = preferedLocale.value
-      }
-    },
   },
 })

--- a/spa-loading-template.html
+++ b/spa-loading-template.html
@@ -51,7 +51,12 @@
 
 <div id="loader">
   <p class="sr-only">Loading</p>
-  <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24">
-    <path fill="currentColor" d="M12 4V2A10 10 0 0 0 2 12h2a8 8 0 0 1 8-8Z"/>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="32"
+    height="32"
+    viewBox="0 0 24 24"
+  >
+    <path fill="currentColor" d="M12 4V2A10 10 0 0 0 2 12h2a8 8 0 0 1 8-8Z" />
   </svg>
 </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
   // https://nuxt.com/docs/guide/concepts/typescript
-  "extends": "./.nuxt/tsconfig.json"
+  "extends": "./.nuxt/tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext"
+  }
 }


### PR DESCRIPTION
## Problem
- In the header, if we hover the user info, a pencil appear, clicking on the header route us to user profile edition. The whole thing is not good ux.
- If we change the preferred locale, the footer is not updated, and on page load the preferred locale is not used.

## Solution
- always show the pencil, display the label on icon/link hover/focus, only the link is clickable
- use nuxt-i18n cookie strategy to save the preferred locale
- also run lint

## Preview
normal
![image](https://github.com/user-attachments/assets/20a34324-6077-453e-8831-04e53e23242c)
hovered/focused
![image](https://github.com/user-attachments/assets/5bc531c1-ea93-43c3-9b47-43acd1a2feb2)


## PR Status
OK

fix https://github.com/YunoHost/issues/issues/2446
fix https://github.com/YunoHost/issues/issues/2442