### PR TITLE
Add empty <div> placeholder for apps without logo

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -124,6 +124,13 @@ const tileClasses = computed(() => {
             :class="tileClasses.img"
             alt=""
           />
+          <div
+            v-else-if="settings.portal_tile_theme !== 'periodic'"
+            aria-hidden
+            class="app-logo w-24 h-24 min-w-24 rounded-xl"
+            :class="tileClasses.img"
+            alt=""
+          /></div>
           <div>
             <h4
               :data-initials="app.initials"


### PR DESCRIPTION
Hello,

Currently in YNH 12.1.0 testing, app tiles without logo (several apps in the catalog comes that way - e.g. if-config-io, xprober, agewasm, etc.) see their title misaligned with the other tiles' titles (with logo), giving a kind of broken look.

![screen](https://github.com/user-attachments/assets/2444b3fa-44b8-4a28-a9de-7ca4de5e9191)

This PR adds a `<div>` element to act as a placeholder for the logo so that all app titles remain aligned whether they have a logo or not.
It uses `<div>` instead of `<img>` since an `<img>` without `src` attribute necessarily comes with borders that wouldn't look so nice here.

Here is the expected result: 
![screen2](https://github.com/user-attachments/assets/772546cd-c05d-4ae2-9070-0ceac23e0c1f)

I can also think of 2 alternative proposals:
1. add the app initials within the div to serve as a default logo together with a dedicated class
  ```vue
  <div
    v-else-if="settings.portal_tile_theme !== 'periodic'"
    aria-hidden
    class="app-logo w-24 h-24 min-w-24 rounded-xl default-logo"
    :class="tileClasses.img"
    alt=""
  />app.initials</div>
  ```
  ```css
  .default-logo{
    align-content: center;
    text-transform: uppercase;
    font-size: 70px;
  }
  ```
![screen3](https://github.com/user-attachments/assets/246c662d-7070-4756-b83d-ee3c93926cae)

2. use `<img>` instead with a default image placeholder (i know there is a rich base of YNH fan art somewhere that could maybe help) for apps without logo.
