### PR TITLE
Add app logo placeholder

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -117,9 +117,9 @@ const tileClasses = computed(() => {
           :style="`--label-hash: ${app.label_hash}`"
         >
           <img
-            v-if="app.logo && settings.portal_tile_theme !== 'periodic'"
+            v-if="settings.portal_tile_theme !== 'periodic'"
             aria-hidden
-            :src="app.logo"
+            :src="app.logo ? app.logo : data:image/png;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
             class="app-logo w-24 h-24 min-w-24 rounded-xl"
             :class="tileClasses.img"
             alt=""


### PR DESCRIPTION
Hello,

Currently in YNH 12.1.0 testing, app tiles without logo (several apps in the catalog comes that way - e.g. if-config-io, xprober, agewasm, etc.) see their title misaligned with the other tiles' titles (with logo), giving a kind of broken look.

![screen](https://github.com/user-attachments/assets/f720dddd-1d18-4253-a4ed-c0e61363d462)

This PR adds a 1 pixel PNG element as placeholder for `<img>` src attribute if the app has no `app.logo` defined so that all app titles remain aligned whether they have a logo or not.
The 1px-image placeholder is required because a `<img>` tag without `src` attribute shows borders that wouldn't look so nice here.

Here is the expected result: 

![screen2](https://github.com/user-attachments/assets/503f54c6-c405-4d3b-ba5e-7141678cface)

I can also think of 2 alternative proposals:
1. use a `<div>` fallback option that contains the app initials to serve as a default logo together with a dedicated class
    ```vue
    <img
      v-if="app.logo && settings.portal_tile_theme !== 'periodic'"
      aria-hidden
      :src="app.logo"
      class="app-logo w-24 h-24 min-w-24 rounded-xl"
      :class="tileClasses.img"
      alt=""
    />
    <div
      v-else-if="settings.portal_tile_theme !== 'periodic'"
      aria-hidden
      class="app-logo w-24 h-24 min-w-24 rounded-xl default-logo"
      :class="tileClasses.img"
      alt=""
    />app.initials</div>
    ```
    ```css
    .default-logo{
      align-content: center;
      text-transform: uppercase;
      font-size: 70px;
    }
    ```
    ![screen3](https://github.com/user-attachments/assets/246c662d-7070-4756-b83d-ee3c93926cae)

2. instead of a 1-pixel sized placeholder, use a real image placeholder (i know there is a rich base of YNH fan art somewhere that could maybe help).
