### PR TITLE
Permit autocompletion for the 'confirm password' field

### DIFF
--- a/components/UserPasswordForm.vue
+++ b/components/UserPasswordForm.vue
@@ -114,7 +114,12 @@ const onSubmit = handleSubmit(async (form) => {
     </FormField>
 
     <FormField name="confirmpassword" :label="$t('confirm_new_password')">
-      <TextInput name="confirmpassword" type="password" class="w-full" />
+      <TextInput
+        name="confirmpassword"
+        type="password"
+        autocomplete="new-password"
+        class="w-full" 
+      />
     </FormField>
   </YForm>
 </template>


### PR DESCRIPTION
if it's automatically completed, it should be identical so it's useless to force the user to copy paste it