### PR TITLE
the list of apps should be h3 and not h4

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -125,13 +125,13 @@ const tileClasses = computed(() => {
             alt=""
           />
           <div>
-            <h4
+            <h3
               :data-initials="app.initials"
               class="app-label break-words"
               :class="tileClasses.title"
             >
               <a :href="app.url" class="">{{ app.label }}</a>
-            </h4>
+            </h3>
             <p
               v-if="
                 app.description && settings.portal_tile_theme === 'descriptive'


### PR DESCRIPTION
the list of apps should be h3 and not h4 as they are directly children of the "App list" h2 (line `101`)

note: this has not been tested