### PR TITLE
[fix] 8 chars min is displayed in description and errors even if it's more

### DIFF
--- a/components/UserPasswordForm.vue
+++ b/components/UserPasswordForm.vue
@@ -7,6 +7,25 @@ import type { Feedback } from '@/composables/form'
 
 const { t } = useI18n()
 
+const settings = await useSettings()
+const user = await useUser()
+// Length, digits, lowers, uppers, others
+// Sync this data with src/utils/password.py
+const strengthLevels: Array = [
+    [8, 0, 0, 0, 0],
+    [8, 1, 1, 1, 0],
+    [8, 1, 1, 1, 1],
+    [10, 1, 1, 1, 1],
+    [12, 1, 1, 1, 1],
+    [15, 1, 1, 1, 1],
+    [30, 0, 1, 0, 0],
+]
+let strengthLevel: string
+if (user.value.groups.includes("admins"))
+    strengthLevel = settings.value.admin_strength
+else
+    strengthLevel = settings.value.user_strength
+let passwordMin = (strengthLevel!="-1") ? strengthLevels[Number(strengthLevel)][0]:1
 const loading: Ref<boolean> = ref(false)
 const feedback: Ref<Feedback> = ref(null)
 
@@ -16,10 +35,11 @@ const { handleSubmit, setFieldError, resetForm, meta } = useForm({
       currentpassword: yup.string().required(),
       newpassword: yup
         .string()
-        .matches(/.{8,}/, {
-          excludeEmptyString: true,
-          message: { key: 'v.string_too_short', values: { min: 8 } },
-        })
+        .max(126, 
+          { key: 'v.string_too_long', values: { max: 126 }})
+        .min(passwordMin, 
+          { key:'v.string_too_short', values: { min: passwordMin } }
+        )
         .required(),
       confirmpassword: yup
         .string()
@@ -102,7 +122,7 @@ const onSubmit = handleSubmit(async (form) => {
     <FormField
       name="newpassword"
       :label="$t('new_password')"
-      :description="$t('good_practices_about_user_password')"
+      :description="$t('good_practices_about_user_password', {min: passwordMin})"
       class="mb-3"
     >
       <TextInput

--- a/components/UserPasswordForm.vue
+++ b/components/UserPasswordForm.vue
@@ -12,6 +12,7 @@ const user = await useUser()
 // Length, digits, lowers, uppers, others
 // Sync this data with src/utils/password.py
 const strengthLevels: Array = [
+    [1, 0, 0, 0, 0],
     [8, 0, 0, 0, 0],
     [8, 1, 1, 1, 0],
     [8, 1, 1, 1, 1],
@@ -25,7 +26,7 @@ if (user.value.groups.includes("admins"))
     strengthLevel = settings.value.admin_strength
 else
     strengthLevel = settings.value.user_strength
-let passwordMin = (strengthLevel!="-1") ? strengthLevels[Number(strengthLevel)][0]:1
+let passwordMin = strengthLevels[Number(strengthLevel) + 1][0]
 const loading: Ref<boolean> = ref(false)
 const feedback: Ref<Feedback> = ref(null)
 

--- a/composables/states.ts
+++ b/composables/states.ts
@@ -99,6 +99,8 @@ export interface Settings {
   show_other_domains_apps: 0 | 1
   portal_user_intro: string
   portal_public_intro: string
+  admin_strength: string
+  user_strength: string
   apps: AppsSettings
 }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -25,7 +25,7 @@
     "footerlink_support": "Support",
     "form_has_errors": "The form contains some errors",
     "fullname": "Full name",
-    "good_practices_about_user_password": "Pick a user password of at least 8 characters - though it is good practice to use longer ones (i.e. a passphrase) and/or use various kind of characters (uppercase, lowercase, digits and special characters).",
+    "good_practices_about_user_password": "Pick a user password of at least {min} characters - though it is good practice to use longer ones (i.e. a passphrase) and/or use various kind of characters (uppercase, lowercase, digits and special characters).",
     "language": "Language",
     "logged_out": "Logged out",
     "login": "Log in",
@@ -64,6 +64,7 @@
         "field_invalid": "Field value is invalid",
         "field_required": "Field value is required",
         "password_not_match": "Passwords don't match.",
-        "string_too_short": "Invalid value: must be at least {min} characters"
+        "string_too_short": "Invalid value: must be at least {min} characters",
+        "string_too_long": "Invalid value: {max} characters maximum"
     }
 }


### PR DESCRIPTION
## The problem

Password min length is hardcoded (at 8), it's not a problem cause a bug with new portal api deactivate the admin choice for user_strength and admin_strength through portal_update o_O  !

As i fixed the bug in yunohost-portal-api, it's needed to display the good value in description and error message.

Related PR: https://github.com/YunoHost/yunohost/pull/2311

## The solution
 - Use a settings to get the strength validation level for admin and user profile
 - Hardcode the strengthLevels array with all requirements.
 - Don't check for digit, lower, upper and special chars, cause 30 chars passphrase are accepted... And a server validation error message is displayed in last anyway
 - Limit at 126 chars (as LDAP doesn't accept more)

## Status
Partially tested manually with ynh-dev

## DEV TODO
 - [ ] Don't return admin_strength if user is not in admins group ? But i don't know how it could be for self-registration
 - [ ] Merge with self-registration code (the new register page need adjustment)
 - [ ] Display `Pick a user password of at least 1 characters - though it is good practice to use longer ones (i.e. a passphrase) and/or use various kind of characters (uppercase, lowercase, digits and special characters).` is a bit weird when admins has deactivated user_strength with -1...

## TESTS TODO
 - [x] Try with an admin user
 - [ ] Try all strength level
 - [ ] Try with a simple user (not admin)
